### PR TITLE
test: ensure path params are URL decoded

### DIFF
--- a/http-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
+++ b/http-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
@@ -48,6 +48,7 @@ import io.ktor.server.routing.RouteSelector
 import io.ktor.server.routing.RoutingCall
 import io.ktor.server.routing.RoutingHandler
 import io.ktor.server.routing.RoutingNode
+import io.ktor.http.decodeURLPart
 import io.ktor.utils.io.availableForRead
 import io.ktor.utils.io.core.remaining
 import io.ktor.utils.io.jvm.javaio.toInputStream
@@ -95,7 +96,10 @@ private fun <Path, Input, Error, Output> httpRoutingHandler(
         return@interceptor call.respond(HttpStatusCode.MethodNotAllowed)
     }
 
-    val rawPath = call.request.path().split("/").filter { it.isNotBlank() }
+    val rawPath = call.request.path()
+        .split("/")
+        .filter { it.isNotBlank() }
+        .map { it.decodeURLPart() }
     val headers = call.request.headers.entries().associate { it.key to it.value }
     val query = call.request.queryParameters.entries().associate { it.key to it.value }
     val path: Path = endpoint.api.params.parseCatching(rawPath.toMutableList(), headers, query).getOrThrow()


### PR DESCRIPTION
## Summary
- validate percent-decoded path parameters with Ktor 3 adapter
- decode URL segments before binding path params

## Testing
- `./gradlew :http-ktor-3:jvmTest --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68b9d88b4dc8832a8eeb4c25da1f6cef