### PR TITLE
chore: require review before Maven Central deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
 #          - module: schema-kotlinx-datetime
 #    runs-on: ubuntu-latest
     runs-on: macos-latest
+    environment: maven-central
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Summary
- gate Maven Central releases behind `maven-central` environment review

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b9e5dbf8b8832a9b342e9ef6f7a9c5