### PR TITLE
fix(client): typed stream outcome via `HttpResult<E, Flow<SSEEvent<O>>>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Katalyst supports real-time streaming via SSE:
 
 ```kotlin
 val streamApi = Http.get { Root / "events" }
-    .output { sse { json { messageSchema } } }
+    .output { sse(Ok) { json { messageSchema } } }
 
 // In your server setup:
 handle(streamApi) {

--- a/http-client-ktor-3/readme.md
+++ b/http-client-ktor-3/readme.md
@@ -101,18 +101,23 @@ val result = client.call(api)
 
 ## SSE Streaming
 
-For endpoints that return Server-Sent Events, use `stream()` which returns a `Flow<SSEEvent<O>>`:
+For endpoints that return Server-Sent Events, use `stream()`. It suspends until the server responds with headers, then returns an `HttpResult<E, Flow<SSEEvent<O>>>` — mirroring `call()`'s result shape, with the success case carrying the event flow:
 
 ```kotlin
 val streamApi = Http.get { Root / "stream" }
-    .output { sse { json { string() } } }
+    .output { sse(Ok) { json { string() } } }
+    .error { status(Conflict) { json { errorSchema } } }
 
-val events: Flow<SSEEvent<String>> = client.stream(streamApi)
-
-events.collect { event ->
-    println("Received: ${event.data}")
+when (val result = client.stream(streamApi)) {
+    is HttpResult.Failure -> println("HTTP ${result.status}: ${result.error}")
+    is HttpResult.NetworkError -> println("Transport error: ${result.cause}")
+    is HttpResult.Success -> result.value
+        .catch { e -> println("Mid-stream error: $e") }
+        .collect { event -> println("Received: ${event.data}") }
 }
 ```
+
+A typed `Failure` or pre-flight `NetworkError` can only be the terminal outcome — once the connection is established, events flow through `Success` and mid-stream transport errors surface as exceptions on the inner flow (handle via `.catch { }`).
 
 Each `SSEEvent` carries optional `data`, `event`, `id`, `retry`, and `comment` fields.
 

--- a/http-client-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClient.kt
+++ b/http-client-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClient.kt
@@ -32,6 +32,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
 import io.ktor.client.statement.readRawBytes
+import io.ktor.http.contentType
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.Parameters
@@ -42,9 +43,11 @@ import io.ktor.utils.io.readLine
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmName
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
@@ -102,6 +105,21 @@ class KatalystClient(
         auth: AuthCredential? = null
     ): HttpResult<E, O> = call(endpoint, Unit, input, auth)
 
+    /**
+     * Opens an SSE stream. Suspends until the server returns response headers,
+     * then returns a typed outcome:
+     *  - [HttpResult.Failure] — server responded with a declared error status and body
+     *  - [HttpResult.NetworkError] — transport, undeclared status, decode failure, or
+     *    pre-flight cancellation
+     *  - [HttpResult.Success] — the inner [Flow] yields SSE events until the connection
+     *    closes. Mid-stream transport failures surface as exceptions on the flow (use
+     *    [kotlinx.coroutines.flow.catch]).
+     *
+     * The returned flow is single-consumer. It **must be collected** (or the enclosing
+     * coroutine cancelled) for the connection to be released — if a caller receives
+     * [HttpResult.Success] and never subscribes, the request stays open until the caller's
+     * coroutine scope is cancelled.
+     */
     suspend fun <P, I, E, O, A> stream(
         endpoint: Http<P, I, E, O, A>,
         params: P,
@@ -111,8 +129,9 @@ class KatalystClient(
         val rendered = endpoint.params.render(params)
         val events = Channel<SSEEvent<O>>(Channel.BUFFERED)
         val outcome = CompletableDeferred<HttpResult<E, Unit>>()
+        val scope = CoroutineScope(currentCoroutineContext())
 
-        val job = httpClient.launch {
+        val job = scope.launch {
             try {
                 httpClient.prepareRequest {
                     method = endpoint.method.toKtorMethod()
@@ -129,7 +148,8 @@ class KatalystClient(
                     header(HttpHeaders.CacheControl, "no-store")
                 }.execute { response ->
                     val statusCode = response.status.value
-                    when (val match = matchStatusSchema(endpoint, statusCode)) {
+                    val isEventStream = response.isEventStream()
+                    when (val match = matchStatusSchema(endpoint, statusCode, isEventStream)) {
                         is StatusMatch.EventStream<O> -> {
                             outcome.complete(HttpResult.Success(Unit))
                             try {
@@ -212,44 +232,48 @@ class KatalystClient(
     ): HttpResult<E, Flow<SSEEvent<O>>> = stream(endpoint, Unit, input, auth)
 }
 
+private fun HttpResponse.isEventStream(): Boolean =
+    contentType()?.match(io.ktor.http.ContentType.Text.EventStream) == true
+
 private suspend fun <O> streamEvents(
     channel: ByteReadChannel,
     bodySchema: BodySchema<O>,
     events: SendChannel<SSEEvent<O>>
 ) {
     var eventType: String? = null
-    var dataLines = mutableListOf<String>()
+    val dataLines = mutableListOf<String>()
     var eventId: String? = null
     var retry: Long? = null
     var comment: String? = null
+
+    suspend fun flushEvent() {
+        if (dataLines.isEmpty() && comment == null) return
+        val data = if (dataLines.isNotEmpty()) {
+            val raw = dataLines.joinToString("\n")
+            if (raw.isBlank() || raw == "null") null else decodeBody(bodySchema, raw.encodeToByteArray())
+        } else null
+
+        events.send(
+            SSEEvent(
+                data = data,
+                event = eventType,
+                id = eventId,
+                retry = retry,
+                comment = comment
+            )
+        )
+        eventType = null
+        dataLines.clear()
+        eventId = null
+        retry = null
+        comment = null
+    }
 
     while (!channel.isClosedForRead) {
         val line = channel.readLine() ?: break
 
         when {
-            line.isEmpty() -> {
-                if (dataLines.isNotEmpty() || comment != null) {
-                    val data = if (dataLines.isNotEmpty()) {
-                        val raw = dataLines.joinToString("\n")
-                        if (raw.isBlank() || raw == "null") null else decodeBody(bodySchema, raw.encodeToByteArray())
-                    } else null
-
-                    events.send(
-                        SSEEvent(
-                            data = data,
-                            event = eventType,
-                            id = eventId,
-                            retry = retry,
-                            comment = comment
-                        )
-                    )
-                }
-                eventType = null
-                dataLines = mutableListOf()
-                eventId = null
-                retry = null
-                comment = null
-            }
+            line.isEmpty() -> flushEvent()
 
             line.startsWith(":") -> {
                 comment = line.removePrefix(": ").takeIf { it.isNotBlank() }
@@ -262,6 +286,8 @@ private suspend fun <O> streamEvents(
             line.startsWith("retry:") -> retry = line.removePrefix("retry:").removePrefix(" ").toLongOrNull()
         }
     }
+
+    flushEvent()
 }
 
 private fun HttpMethod.toKtorMethod(): io.ktor.http.HttpMethod =
@@ -438,15 +464,21 @@ private sealed interface StatusMatch<out E, out O> {
 @Suppress("UNCHECKED_CAST")
 private fun <P, I, E, O, A> matchStatusSchema(
     endpoint: Http<P, I, E, O, A>,
-    statusCode: Int
+    statusCode: Int,
+    isEventStream: Boolean
 ): StatusMatch<E, O> {
-    endpoint.output.schemaByStatus().entries
+    val matchedOutput = endpoint.output.schemaByStatus().entries
         .firstOrNull { it.key.code == statusCode }
-        ?.let { return StatusMatch.Output(it.value as BodySchema<O>) }
-
-    endpoint.output.findEventStream()
+    val matchedEventStream = endpoint.output.findEventStream()
         ?.takeIf { it.status.code == statusCode }
-        ?.let { return StatusMatch.EventStream(it.bodySchema) }
+
+    if (isEventStream) {
+        matchedEventStream?.let { return StatusMatch.EventStream(it.bodySchema) }
+        matchedOutput?.let { return StatusMatch.Output(it.value as BodySchema<O>) }
+    } else {
+        matchedOutput?.let { return StatusMatch.Output(it.value as BodySchema<O>) }
+        matchedEventStream?.let { return StatusMatch.EventStream(it.bodySchema) }
+    }
 
     endpoint.error.schemaByStatus().entries
         .firstOrNull { it.key.code == statusCode }
@@ -461,8 +493,9 @@ private suspend fun <P, I, E, O, A> decodeResponse(
 ): HttpResult<E, O> {
     val statusCode = response.status.value
     val bytes = response.readRawBytes()
+    val isEventStream = response.isEventStream()
 
-    return when (val match = matchStatusSchema(endpoint, statusCode)) {
+    return when (val match = matchStatusSchema(endpoint, statusCode, isEventStream)) {
         is StatusMatch.Output<O> -> runCatching { decodeBody(match.schema, bytes) }
             .fold(onSuccess = { HttpResult.Success(it) }, onFailure = { HttpResult.NetworkError(it) })
 

--- a/http-client-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClient.kt
+++ b/http-client-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClient.kt
@@ -41,8 +41,14 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readLine
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmName
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
 
 class KatalystClient(
     val httpClient: HttpClient
@@ -96,98 +102,166 @@ class KatalystClient(
         auth: AuthCredential? = null
     ): HttpResult<E, O> = call(endpoint, Unit, input, auth)
 
-    fun <P, I, E, O, A> stream(
+    suspend fun <P, I, E, O, A> stream(
         endpoint: Http<P, I, E, O, A>,
         params: P,
         input: I,
         auth: AuthCredential? = null
-    ): Flow<SSEEvent<O>> = channelFlow {
+    ): HttpResult<E, Flow<SSEEvent<O>>> {
         val rendered = endpoint.params.render(params)
-        val eventStream = endpoint.output.findEventStream()
-            ?: error("Endpoint output schema has no SSE EventStream variant")
+        val events = Channel<SSEEvent<O>>(Channel.BUFFERED)
+        val outcome = CompletableDeferred<HttpResult<E, Unit>>()
 
-        httpClient.prepareRequest {
-            method = endpoint.method.toKtorMethod()
-            url { appendPathSegments(rendered.pathSegments) }
-            rendered.queryParams.forEach { (name, values) ->
-                values.forEach { value -> url.parameters.append(name, value) }
-            }
-            rendered.headers.forEach { (name, values) ->
-                values.forEach { value -> header(name, value) }
-            }
-            applyAuth(endpoint.auth, auth)
-            applyBody(endpoint.input, input)
-            header(HttpHeaders.Accept, "text/event-stream")
-            header(HttpHeaders.CacheControl, "no-store")
-        }.execute { response ->
-            val channel: ByteReadChannel = response.bodyAsChannel()
-            var eventType: String? = null
-            var dataLines = mutableListOf<String>()
-            var eventId: String? = null
-            var retry: Long? = null
-            var comment: String? = null
-
-            while (!channel.isClosedForRead) {
-                val line = channel.readLine() ?: break
-
-                when {
-                    line.isEmpty() -> {
-                        if (dataLines.isNotEmpty() || comment != null) {
-                            val data = if (dataLines.isNotEmpty()) {
-                                val raw = dataLines.joinToString("\n")
-                                if (raw.isBlank() || raw == "null") null else decodeBody(eventStream.bodySchema, raw.encodeToByteArray())
-                            } else null
-
-                            send(
-                                SSEEvent(
-                                    data = data,
-                                    event = eventType,
-                                    id = eventId,
-                                    retry = retry,
-                                    comment = comment
-                                )
-                            )
+        val job = httpClient.launch {
+            try {
+                httpClient.prepareRequest {
+                    method = endpoint.method.toKtorMethod()
+                    url { appendPathSegments(rendered.pathSegments) }
+                    rendered.queryParams.forEach { (name, values) ->
+                        values.forEach { value -> url.parameters.append(name, value) }
+                    }
+                    rendered.headers.forEach { (name, values) ->
+                        values.forEach { value -> header(name, value) }
+                    }
+                    applyAuth(endpoint.auth, auth)
+                    applyBody(endpoint.input, input)
+                    header(HttpHeaders.Accept, "text/event-stream")
+                    header(HttpHeaders.CacheControl, "no-store")
+                }.execute { response ->
+                    val statusCode = response.status.value
+                    when (val match = matchStatusSchema(endpoint, statusCode)) {
+                        is StatusMatch.EventStream<O> -> {
+                            outcome.complete(HttpResult.Success(Unit))
+                            try {
+                                streamEvents(response.bodyAsChannel(), match.schema, events)
+                                events.close()
+                            } catch (e: CancellationException) {
+                                events.close(e)
+                                throw e
+                            } catch (e: Throwable) {
+                                events.close(e)
+                            }
                         }
-                        eventType = null
-                        dataLines = mutableListOf()
-                        eventId = null
-                        retry = null
-                        comment = null
-                    }
 
-                    line.startsWith(":") -> {
-                        comment = line.removePrefix(": ").takeIf { it.isNotBlank() }
-                            ?: line.removePrefix(":").takeIf { it.isNotBlank() }
-                    }
+                        is StatusMatch.Error<E> -> {
+                            outcome.complete(decodeFailure(match.schema, statusCode, response.readRawBytes()))
+                            events.close()
+                        }
 
-                    line.startsWith("event:") -> eventType = line.removePrefix("event:").removePrefix(" ")
-                    line.startsWith("data:") -> dataLines.add(line.removePrefix("data:").removePrefix(" "))
-                    line.startsWith("id:") -> eventId = line.removePrefix("id:").removePrefix(" ")
-                    line.startsWith("retry:") -> retry = line.removePrefix("retry:").removePrefix(" ").toLongOrNull()
+                        is StatusMatch.Output<O> -> {
+                            outcome.complete(HttpResult.NetworkError(
+                                IllegalStateException("Stream endpoint returned non-SSE success $statusCode")
+                            ))
+                            events.close()
+                        }
+
+                        StatusMatch.Unmatched -> {
+                            val bytes = response.readRawBytes()
+                            outcome.complete(HttpResult.NetworkError(
+                                IllegalStateException("Unexpected status $statusCode: ${bytes.decodeToString()}")
+                            ))
+                            events.close()
+                        }
+                    }
                 }
+            } catch (e: CancellationException) {
+                if (!outcome.isCompleted) outcome.completeExceptionally(e)
+                events.close(e)
+                throw e
+            } catch (e: Throwable) {
+                if (!outcome.isCompleted) outcome.complete(HttpResult.NetworkError(e))
+                events.close(e)
             }
+        }
+
+        val result = try {
+            outcome.await()
+        } catch (e: Throwable) {
+            job.cancel()
+            throw e
+        }
+
+        return when (result) {
+            is HttpResult.Success -> HttpResult.Success(
+                flow { events.consumeEach { emit(it) } }
+                    .onCompletion { job.cancel() }
+            )
+            is HttpResult.Failure -> result
+            is HttpResult.NetworkError -> result
         }
     }
 
     @JvmName("streamNoParamsNoInput")
-    fun <E, O, A> stream(
+    suspend fun <E, O, A> stream(
         endpoint: Http<Unit, Nothing?, E, O, A>,
         auth: AuthCredential? = null
-    ): Flow<SSEEvent<O>> = stream(endpoint, Unit, null, auth)
+    ): HttpResult<E, Flow<SSEEvent<O>>> = stream(endpoint, Unit, null, auth)
 
     @JvmName("streamNoInput")
-    fun <P, E, O, A> stream(
+    suspend fun <P, E, O, A> stream(
         endpoint: Http<P, Nothing?, E, O, A>,
         params: P,
         auth: AuthCredential? = null
-    ): Flow<SSEEvent<O>> = stream(endpoint, params, null, auth)
+    ): HttpResult<E, Flow<SSEEvent<O>>> = stream(endpoint, params, null, auth)
 
     @JvmName("streamNoParams")
-    fun <I, E, O, A> stream(
+    suspend fun <I, E, O, A> stream(
         endpoint: Http<Unit, I, E, O, A>,
         input: I,
         auth: AuthCredential? = null
-    ): Flow<SSEEvent<O>> = stream(endpoint, Unit, input, auth)
+    ): HttpResult<E, Flow<SSEEvent<O>>> = stream(endpoint, Unit, input, auth)
+}
+
+private suspend fun <O> streamEvents(
+    channel: ByteReadChannel,
+    bodySchema: BodySchema<O>,
+    events: SendChannel<SSEEvent<O>>
+) {
+    var eventType: String? = null
+    var dataLines = mutableListOf<String>()
+    var eventId: String? = null
+    var retry: Long? = null
+    var comment: String? = null
+
+    while (!channel.isClosedForRead) {
+        val line = channel.readLine() ?: break
+
+        when {
+            line.isEmpty() -> {
+                if (dataLines.isNotEmpty() || comment != null) {
+                    val data = if (dataLines.isNotEmpty()) {
+                        val raw = dataLines.joinToString("\n")
+                        if (raw.isBlank() || raw == "null") null else decodeBody(bodySchema, raw.encodeToByteArray())
+                    } else null
+
+                    events.send(
+                        SSEEvent(
+                            data = data,
+                            event = eventType,
+                            id = eventId,
+                            retry = retry,
+                            comment = comment
+                        )
+                    )
+                }
+                eventType = null
+                dataLines = mutableListOf()
+                eventId = null
+                retry = null
+                comment = null
+            }
+
+            line.startsWith(":") -> {
+                comment = line.removePrefix(": ").takeIf { it.isNotBlank() }
+                    ?: line.removePrefix(":").takeIf { it.isNotBlank() }
+            }
+
+            line.startsWith("event:") -> eventType = line.removePrefix("event:").removePrefix(" ")
+            line.startsWith("data:") -> dataLines.add(line.removePrefix("data:").removePrefix(" "))
+            line.startsWith("id:") -> eventId = line.removePrefix("id:").removePrefix(" ")
+            line.startsWith("retry:") -> retry = line.removePrefix("retry:").removePrefix(" ").toLongOrNull()
+        }
+    }
 }
 
 private fun HttpMethod.toKtorMethod(): io.ktor.http.HttpMethod =
@@ -354,7 +428,33 @@ private fun ParametersBuilder.encodeFormField(name: String, schema: Schema<Any?>
     }
 }
 
+private sealed interface StatusMatch<out E, out O> {
+    data class Output<O>(val schema: BodySchema<O>) : StatusMatch<Nothing, O>
+    data class EventStream<O>(val schema: BodySchema<O>) : StatusMatch<Nothing, O>
+    data class Error<E>(val schema: BodySchema<E>) : StatusMatch<E, Nothing>
+    data object Unmatched : StatusMatch<Nothing, Nothing>
+}
+
 @Suppress("UNCHECKED_CAST")
+private fun <P, I, E, O, A> matchStatusSchema(
+    endpoint: Http<P, I, E, O, A>,
+    statusCode: Int
+): StatusMatch<E, O> {
+    endpoint.output.schemaByStatus().entries
+        .firstOrNull { it.key.code == statusCode }
+        ?.let { return StatusMatch.Output(it.value as BodySchema<O>) }
+
+    endpoint.output.findEventStream()
+        ?.takeIf { it.status.code == statusCode }
+        ?.let { return StatusMatch.EventStream(it.bodySchema) }
+
+    endpoint.error.schemaByStatus().entries
+        .firstOrNull { it.key.code == statusCode }
+        ?.let { return StatusMatch.Error(it.value as BodySchema<E>) }
+
+    return StatusMatch.Unmatched
+}
+
 private suspend fun <P, I, E, O, A> decodeResponse(
     endpoint: Http<P, I, E, O, A>,
     response: HttpResponse
@@ -362,25 +462,32 @@ private suspend fun <P, I, E, O, A> decodeResponse(
     val statusCode = response.status.value
     val bytes = response.readRawBytes()
 
-    val outputByStatus = endpoint.output.schemaByStatus()
-    val errorByStatus = endpoint.error.schemaByStatus()
-
-    val matchedOutput = outputByStatus.entries.firstOrNull { it.key.code == statusCode }
-    if (matchedOutput != null) {
-        return runCatching { decodeBody(matchedOutput.value as BodySchema<O>, bytes) }
+    return when (val match = matchStatusSchema(endpoint, statusCode)) {
+        is StatusMatch.Output<O> -> runCatching { decodeBody(match.schema, bytes) }
             .fold(onSuccess = { HttpResult.Success(it) }, onFailure = { HttpResult.NetworkError(it) })
-    }
 
-    val matchedError = errorByStatus.entries.firstOrNull { it.key.code == statusCode }
-    if (matchedError != null) {
-        return runCatching { decodeBody(matchedError.value as BodySchema<E>, bytes) }
-            .fold(onSuccess = { HttpResult.Failure(statusCode, it) }, onFailure = { HttpResult.NetworkError(it) })
-    }
+        is StatusMatch.EventStream<O> -> HttpResult.NetworkError(
+            IllegalStateException("Endpoint returned an event stream; use stream() instead of call()")
+        )
 
-    return HttpResult.NetworkError(
-        IllegalStateException("Unexpected status $statusCode: ${bytes.decodeToString()}")
-    )
+        is StatusMatch.Error<E> -> decodeFailure(match.schema, statusCode, bytes)
+
+        StatusMatch.Unmatched -> HttpResult.NetworkError(
+            IllegalStateException("Unexpected status $statusCode: ${bytes.decodeToString()}")
+        )
+    }
 }
+
+private fun <E> decodeFailure(
+    schema: BodySchema<E>,
+    statusCode: Int,
+    bytes: ByteArray
+): HttpResult<E, Nothing> =
+    runCatching { decodeBody(schema, bytes) }
+        .fold(
+            onSuccess = { HttpResult.Failure(statusCode, it) },
+            onFailure = { HttpResult.NetworkError(it) }
+        )
 
 @Suppress("UNCHECKED_CAST")
 private fun <A> decodeBody(bodySchema: BodySchema<A>, bytes: ByteArray): A =

--- a/http-client-ktor-3/src/jsTest/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClientJsTest.kt
+++ b/http-client-ktor-3/src/jsTest/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClientJsTest.kt
@@ -5,8 +5,15 @@ import io.github.bbasinsk.http.HttpResult
 import io.github.bbasinsk.schema.Schema
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 
 class KatalystClientJsTest {
@@ -22,5 +29,95 @@ class KatalystClientJsTest {
         val result = KatalystClient(client).call(api)
 
         assertIs<HttpResult.NetworkError>(result)
+    }
+
+    data class ChatError(val code: String)
+
+    private val chatErrorSchema = Schema.record(
+        Schema.field(Schema.string(), "code") { code },
+        ::ChatError
+    )
+
+    @Test
+    fun stream_returns_Failure_on_declared_error_status() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = """{"code":"CONFLICT"}""",
+                status = HttpStatusCode.Conflict,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+            .error { status(Conflict) { json { chatErrorSchema } } }
+
+        val failure = assertIs<HttpResult.Failure<ChatError>>(KatalystClient(client).stream(api))
+        assertEquals(409, failure.status)
+        assertEquals(ChatError("CONFLICT"), failure.error)
+    }
+
+    @Test
+    fun stream_returns_NetworkError_on_undeclared_error_status() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = "boom",
+                status = HttpStatusCode.InternalServerError,
+                headers = headersOf(HttpHeaders.ContentType, "text/plain")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+            .error { status(Conflict) { json { chatErrorSchema } } }
+
+        val networkError = assertIs<HttpResult.NetworkError>(KatalystClient(client).stream(api))
+        assertIs<IllegalStateException>(networkError.cause)
+        assertEquals("Unexpected status 500: boom", networkError.cause.message)
+    }
+
+    @Test
+    fun stream_returns_NetworkError_on_body_decode_failure_for_declared_error_status() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = "not valid json",
+                status = HttpStatusCode.Conflict,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+            .error { status(Conflict) { json { chatErrorSchema } } }
+
+        assertIs<HttpResult.NetworkError>(KatalystClient(client).stream(api))
+    }
+
+    @Test
+    fun stream_returns_NetworkError_on_connection_failure() = runTest {
+        val mockEngine = MockEngine { throw RuntimeException("Connection refused") }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+
+        val networkError = assertIs<HttpResult.NetworkError>(KatalystClient(client).stream(api))
+        assertIs<RuntimeException>(networkError.cause)
+    }
+
+    @Test
+    fun stream_CancellationException_propagates_unchanged() = runTest {
+        val mockEngine = MockEngine { throw CancellationException("cancelled") }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+
+        assertFailsWith<CancellationException> {
+            KatalystClient(client).stream(api)
+        }
     }
 }

--- a/http-client-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClientTest.kt
+++ b/http-client-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClientTest.kt
@@ -321,6 +321,78 @@ class KatalystClientTest {
     }
 
     @Test
+    fun `mid-stream decode failure surfaces as flow exception after prior events`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = "data: \"first\"\n\ndata: not-json-at-all\n\n",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "text/event-stream")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+
+        val result = assertIs<HttpResult.Success<Flow<SSEEvent<String>>>>(KatalystClient(client).stream(api))
+
+        val received = mutableListOf<SSEEvent<String>>()
+        assertFailsWith<Throwable> {
+            result.value.collect { received += it }
+        }
+        assertEquals(1, received.size)
+        assertEquals("first", received.single().data)
+    }
+
+    @Test
+    fun `stream routes to SSE when endpoint declares oneOf(status, sse) at same status`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = "data: \"hello\"\n\n",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "text/event-stream")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output {
+                oneOf(
+                    status(Ok) { json { Schema.string() } },
+                    sse(Ok) { json { Schema.string() } },
+                )
+            }
+
+        val result = assertIs<HttpResult.Success<Flow<SSEEvent<String>>>>(KatalystClient(client).stream(api))
+        val events = result.value.toList()
+        assertEquals(1, events.size)
+        assertEquals("hello", events.single().data)
+    }
+
+    @Test
+    fun `call routes to Success when endpoint declares oneOf(status, sse) and server responds non-SSE`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = "\"hello\"",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output {
+                oneOf(
+                    status(Ok) { json { Schema.string() } },
+                    sse(Ok) { json { Schema.string() } },
+                )
+            }
+
+        val result = assertIs<HttpResult.Success<String>>(KatalystClient(client).call(api))
+        assertEquals("hello", result.value)
+    }
+
+    @Test
     fun `SSE stream with keepalive heartbeats skips null data`() = testApplication {
         val api = Http.get { Root / "heartbeat" }
             .output { sse(Ok) { json { userSchema } } }

--- a/http-client-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClientTest.kt
+++ b/http-client-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/client/ktor3/KatalystClientTest.kt
@@ -24,6 +24,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -202,7 +203,7 @@ class KatalystClientTest {
     @Test
     fun `SSE streaming returns flow of events`() = testApplication {
         val api = Http.get { Root / "stream" }
-            .output { sse { json { string() } } }
+            .output { sse(Ok) { json { string() } } }
 
         application {
             endpoints {
@@ -219,7 +220,8 @@ class KatalystClientTest {
         }
 
         val katalystClient = KatalystClient(client)
-        val events = katalystClient.stream(api).toList()
+        val result = assertIs<HttpResult.Success<Flow<SSEEvent<String>>>>(katalystClient.stream(api))
+        val events = result.value.toList()
 
         assertEquals(3, events.size)
         assertEquals("event-1", events[0].data)
@@ -227,10 +229,101 @@ class KatalystClientTest {
         assertEquals("event-3", events[2].data)
     }
 
+    data class ChatError(val code: String, val message: String)
+
+    val chatErrorSchema: Schema<ChatError> = Schema.record(
+        Schema.field(Schema.string(), "code") { code },
+        Schema.field(Schema.string(), "message") { message },
+        ::ChatError
+    )
+
+    @Test
+    fun `stream returns Failure on declared error status`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = """{"code":"CONFLICT","message":"already exists"}""",
+                status = HttpStatusCode.Conflict,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+            .error { status(Conflict) { json { chatErrorSchema } } }
+
+        val failure = assertIs<HttpResult.Failure<ChatError>>(KatalystClient(client).stream(api))
+        assertEquals(409, failure.status)
+        assertEquals(ChatError("CONFLICT", "already exists"), failure.error)
+    }
+
+    @Test
+    fun `stream returns NetworkError on undeclared error status`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = "boom",
+                status = HttpStatusCode.InternalServerError,
+                headers = headersOf(HttpHeaders.ContentType, "text/plain")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+            .error { status(Conflict) { json { chatErrorSchema } } }
+
+        val networkError = assertIs<HttpResult.NetworkError>(KatalystClient(client).stream(api))
+        assertIs<IllegalStateException>(networkError.cause)
+        assertEquals("Unexpected status 500: boom", networkError.cause.message)
+    }
+
+    @Test
+    fun `stream returns NetworkError on body decode failure for declared error status`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                content = "not valid json",
+                status = HttpStatusCode.Conflict,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+            .error { status(Conflict) { json { chatErrorSchema } } }
+
+        assertIs<HttpResult.NetworkError>(KatalystClient(client).stream(api))
+    }
+
+    @Test
+    fun `stream returns NetworkError on connection failure`() = runTest {
+        val mockEngine = MockEngine { throw IOException("Connection refused") }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+
+        val networkError = assertIs<HttpResult.NetworkError>(KatalystClient(client).stream(api))
+        assertIs<IOException>(networkError.cause)
+    }
+
+    @Test
+    fun `stream CancellationException propagates unchanged`() = runTest {
+        val mockEngine = MockEngine { throw CancellationException("cancelled") }
+        val client = HttpClient(mockEngine)
+
+        val api = Http.post { Root / "chat" }
+            .output { sse(Ok) { json { Schema.string() } } }
+
+        assertFailsWith<CancellationException> {
+            KatalystClient(client).stream(api)
+        }
+    }
+
     @Test
     fun `SSE stream with keepalive heartbeats skips null data`() = testApplication {
         val api = Http.get { Root / "heartbeat" }
-            .output { sse { json { userSchema } } }
+            .output { sse(Ok) { json { userSchema } } }
 
         application {
             endpoints {
@@ -247,7 +340,8 @@ class KatalystClientTest {
         }
 
         val katalystClient = KatalystClient(client)
-        val events = katalystClient.stream(api).toList()
+        val result = assertIs<HttpResult.Success<Flow<SSEEvent<User>>>>(katalystClient.stream(api))
+        val events = result.value.toList()
 
         assertEquals(3, events.size)
         assertEquals(User("Alice", 30), events[0].data)

--- a/http-openapi/src/commonMain/kotlin/io/github/bbasinsk/http/openapi/SpecAdapter.kt
+++ b/http-openapi/src/commonMain/kotlin/io/github/bbasinsk/http/openapi/SpecAdapter.kt
@@ -88,7 +88,7 @@ private fun <Params, Input, Error, Output, Auth> Http<Params, Input, Error, Outp
 ): Operation {
     val responses = when (val out = output) {
         is ResponseSchema.EventStream -> mapOf(
-            "200" to out.bodySchema.toServerSentEventStream(resolver)
+            out.status.code.toString() to out.bodySchema.toServerSentEventStream(resolver)
         )
         else -> (output.schemaByStatus() + error.schemaByStatus()).map { (status, case) ->
             status.code.toString() to case.toResponseObject(status, resolver)

--- a/http-openapi/src/commonTest/kotlin/io/github/bbasinsk/http/openapi/SpecAdapterTest.kt
+++ b/http-openapi/src/commonTest/kotlin/io/github/bbasinsk/http/openapi/SpecAdapterTest.kt
@@ -1417,7 +1417,7 @@ class SSESpecAdapterTest {
     @Test
     fun `should generate OpenAPI for SSE streaming endpoint with simple schema`() {
         val http = Http.get { Root / "stream" }
-            .output { sse { json { string() } } }
+            .output { sse(Ok) { json { string() } } }
 
         val result = listOf(http).toOpenApiSpec(info)
 
@@ -1472,7 +1472,7 @@ class SSESpecAdapterTest {
         }
 
         val http = Http.get { Root / "messages" }
-            .output { sse { json { messageSchema } } }
+            .output { sse(Ok) { json { messageSchema } } }
 
         val result = listOf(http).toOpenApiSpec(info)
 
@@ -1534,7 +1534,7 @@ class SSESpecAdapterTest {
     @Test
     fun `should generate OpenAPI for SSE streaming endpoint with plain text`() {
         val http = Http.get { Root / "plain-stream" }
-            .output { sse { plain { string() } } }
+            .output { sse(Ok) { plain { string() } } }
 
         val result = listOf(http).toOpenApiSpec(info)
 
@@ -1590,7 +1590,7 @@ class SSESpecAdapterTest {
 
         val http = Http.get { Root / "events" }
             .output {
-                sse {
+                sse(Ok) {
                     json { eventSchema }
                         .example("greeting", Event("greeting", "Hello"))
                         .example("farewell", Event("farewell", "Goodbye"))
@@ -1684,7 +1684,7 @@ class SSESpecAdapterTest {
             .output { status(Ok) { json { messageSchema } } }
 
         val streamingHttp = Http.get { Root / "stream" }
-            .output { sse { json { messageSchema } } }
+            .output { sse(Ok) { json { messageSchema } } }
 
         val result = listOf(regularHttp, streamingHttp).toOpenApiSpec(info)
 

--- a/http-server-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
+++ b/http-server-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
@@ -109,7 +109,7 @@ private fun <Path, Input, Error, Output, Auth> httpRoutingHandler(
             is Response.StreamingError -> {
                 val sseSchema = endpoint.api.error.findEventStream() ?: error(
                     "Handler returned StreamingError but error schema has no SSE variant. " +
-                            "Add sse { ... } to your error schema, or use oneOf(..., sse { ... })."
+                            "Add sse(Ok) { ... } to your error schema, or use oneOf(..., sse(Ok) { ... })."
                 )
                 call.respondSSE(sseSchema.bodySchema, response.events)
             }
@@ -117,7 +117,7 @@ private fun <Path, Input, Error, Output, Auth> httpRoutingHandler(
             is Response.StreamingSuccess -> {
                 val sseSchema = endpoint.api.output.findEventStream() ?: error(
                     "Handler returned StreamingSuccess but output schema has no SSE variant. " +
-                            "Add sse { ... } to your output schema, or use oneOf(..., sse { ... })."
+                            "Add sse(Ok) { ... } to your output schema, or use oneOf(..., sse(Ok) { ... })."
                 )
                 call.respondSSE(sseSchema.bodySchema, response.events)
             }

--- a/http-server-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
+++ b/http-server-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
@@ -15,6 +15,7 @@ import io.github.bbasinsk.http.Request
 import io.github.bbasinsk.http.parseCatching
 import io.github.bbasinsk.http.Response
 import io.github.bbasinsk.http.ResponseSchema
+import io.github.bbasinsk.http.ResponseStatus
 import io.github.bbasinsk.http.SSEEvent
 import io.github.bbasinsk.schema.*
 import io.github.bbasinsk.schema.avro.BinaryDeserialization.deserializeIgnoringSchemaId
@@ -109,17 +110,17 @@ private fun <Path, Input, Error, Output, Auth> httpRoutingHandler(
             is Response.StreamingError -> {
                 val sseSchema = endpoint.api.error.findEventStream() ?: error(
                     "Handler returned StreamingError but error schema has no SSE variant. " +
-                            "Add sse(Ok) { ... } to your error schema, or use oneOf(..., sse(Ok) { ... })."
+                            "Add sse(<status>) { ... } to your error schema, or use oneOf(..., sse(<status>) { ... })."
                 )
-                call.respondSSE(sseSchema.bodySchema, response.events)
+                call.respondSSE(sseSchema.status, sseSchema.bodySchema, response.events)
             }
 
             is Response.StreamingSuccess -> {
                 val sseSchema = endpoint.api.output.findEventStream() ?: error(
                     "Handler returned StreamingSuccess but output schema has no SSE variant. " +
-                            "Add sse(Ok) { ... } to your output schema, or use oneOf(..., sse(Ok) { ... })."
+                            "Add sse(<status>) { ... } to your output schema, or use oneOf(..., sse(<status>) { ... })."
                 )
-                call.respondSSE(sseSchema.bodySchema, response.events)
+                call.respondSSE(sseSchema.status, sseSchema.bodySchema, response.events)
             }
         }
     } catch (e: CancellationException) {
@@ -343,10 +344,15 @@ data class SchemaError(
  * avoiding the Writer/OutputStream layer whose implicit close/flush can throw
  * [io.ktor.utils.io.ClosedByteChannelException] when the HTTP/2 stream has already closed.
  */
-private suspend fun <A> RoutingCall.respondSSE(bodySchema: BodySchema<A>, events: Flow<SSEEvent<A>>) {
+private suspend fun <A> RoutingCall.respondSSE(
+    responseStatus: ResponseStatus,
+    bodySchema: BodySchema<A>,
+    events: Flow<SSEEvent<A>>
+) {
     val routingCall = this
     respond(object : OutgoingContent.WriteChannelContent() {
         override val contentType = io.ktor.http.ContentType.Text.EventStream
+        override val status = HttpStatusCode.fromValue(responseStatus.code)
 
         override suspend fun writeTo(channel: ByteWriteChannel) {
             try {

--- a/http-server-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor3/Example.kt
+++ b/http-server-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor3/Example.kt
@@ -93,7 +93,7 @@ object SSEEndpoints : HttpEndpointGroup("SSE") {
 
     val longLivedStream = http {
         get { Root / "sse" / "heartbeat" }
-            .output { sse { json { heartbeatSchema } } }
+            .output { sse(Ok) { json { heartbeatSchema } } }
     }
 }
 

--- a/http-server-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor3/SSETest.kt
+++ b/http-server-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor3/SSETest.kt
@@ -33,7 +33,7 @@ class SSETest {
         )
 
         val api = Http.get { Root / "stream" }
-            .output { sse { json { messageSchema } } }
+            .output { sse(Ok) { json { messageSchema } } }
 
         application {
             endpoints {
@@ -73,7 +73,7 @@ class SSETest {
     @Test
     fun `test SSE stream with custom event types`() = testApplication {
         val api = Http.get { Root / "events" }
-            .output { sse { json { string() } } }
+            .output { sse(Ok) { json { string() } } }
 
         application {
             endpoints {
@@ -112,7 +112,7 @@ class SSETest {
     @Test
     fun `test SSE stream with event IDs`() = testApplication {
         val api = Http.get { Root / "numbered" }
-            .output { sse { json { Schema.int() } } }
+            .output { sse(Ok) { json { Schema.int() } } }
 
         application {
             endpoints {
@@ -157,7 +157,7 @@ class SSETest {
     @Test
     fun `test SSE stream with retry configuration`() = testApplication {
         val api = Http.get { Root / "retry" }
-            .output { sse { json { string() } } }
+            .output { sse(Ok) { json { string() } } }
 
         application {
             endpoints {
@@ -192,7 +192,7 @@ class SSETest {
     @Test
     fun `test SSE stream with comments`() = testApplication {
         val api = Http.get { Root / "comments" }
-            .output { sse { json { string() } } }
+            .output { sse(Ok) { json { string() } } }
 
         application {
             endpoints {
@@ -234,7 +234,7 @@ class SSETest {
     @Test
     fun `test SSE stream with plain text content`() = testApplication {
         val api = Http.get { Root / "plain" }
-            .output { sse { plain { string() } } }
+            .output { sse(Ok) { plain { string() } } }
 
         application {
             endpoints {
@@ -280,7 +280,7 @@ class SSETest {
         )
 
         val api = Http.get { Root / "users" }
-            .output { sse { json { userSchema } } }
+            .output { sse(Ok) { json { userSchema } } }
 
         application {
             endpoints {
@@ -320,7 +320,7 @@ class SSETest {
     @Test
     fun `test SSE keepalive with comment-only events`() = testApplication {
         val api = Http.get { Root / "keepalive" }
-            .output { sse { json { string() } } }
+            .output { sse(Ok) { json { string() } } }
 
         application {
             endpoints {
@@ -370,7 +370,7 @@ class SSETest {
 
         val api = Http.get { Root / "error-stream" }
             .output { status(Ok) { json { Schema.string() } } }
-            .error { sse { json { errorSchema } } }
+            .error { sse(Ok) { json { errorSchema } } }
 
         application {
             endpoints {
@@ -409,7 +409,7 @@ class SSETest {
     @Test
     fun `test SSE exception handling sends error event`() = testApplication {
         val api = Http.get { Root / "exception-stream" }
-            .output { sse { json { Schema.string() } } }
+            .output { sse(Ok) { json { Schema.string() } } }
 
         application {
             endpoints {
@@ -458,7 +458,7 @@ class SSETest {
             .output {
                 oneOf(
                     status(Ok) { json { resultSchema } },
-                    sse { json { resultSchema } }
+                    sse(Ok) { json { resultSchema } }
                 )
             }
 
@@ -497,7 +497,7 @@ class SSETest {
     @Test
     fun `test early client disconnect is handled gracefully`() = testApplication {
         val api = Http.get { Root / "long-stream" }
-            .output { sse { json { Schema.int() } } }
+            .output { sse(Ok) { json { Schema.int() } } }
 
         application {
             endpoints {

--- a/http/readme.md
+++ b/http/readme.md
@@ -334,7 +334,7 @@ val messageSchema = Schema.record(
 )
 
 val streamApi = Http.get { Root / "events" }
-    .output { sse { json { messageSchema } } }
+    .output { sse(Ok) { json { messageSchema } } }
 ```
 
 ### Returning Streaming Responses
@@ -393,7 +393,7 @@ SSEEvent(
 ```kotlin
 val api = Http.get { Root / "stream" }
     .output { status(Ok) { json { dataSchema } } }
-    .error { sse { json { errorSchema } } }
+    .error { sse(Ok) { json { errorSchema } } }
 
 handle(api) {
     Response.streamingError(flow {
@@ -490,7 +490,7 @@ For plain text SSE (instead of JSON):
 
 ```kotlin
 val api = Http.get { Root / "log" }
-    .output { sse { plain { string() } } }
+    .output { sse(Ok) { plain { string() } } }
 
 handle(api) {
     Response.streamingSuccessData(flow {
@@ -509,7 +509,7 @@ val api = Http.get { Root / "data" }
     .output {
         oneOf(
             status(Ok) { json { resultSchema } },      // Regular response
-            sse { json { resultSchema } }         // Or streaming
+            sse(Ok) { json { resultSchema } }         // Or streaming
         )
     }
 

--- a/http/src/commonMain/kotlin/io/github/bbasinsk/http/ResponseSchema.kt
+++ b/http/src/commonMain/kotlin/io/github/bbasinsk/http/ResponseSchema.kt
@@ -4,7 +4,7 @@ sealed interface ResponseSchema<A> {
     data object None : ResponseSchema<Nothing>
     data class Multiple<A>(val left: ResponseSchema<A>, val right: ResponseSchema<A>) : ResponseSchema<A>
     data class Single<A, B : A>(val status: ResponseStatus, val res: BodySchema<B>, val deconstruct: (A) -> Boolean) : ResponseSchema<A>
-    data class EventStream<A>(val bodySchema: BodySchema<A>) : ResponseSchema<A>
+    data class EventStream<A>(val status: ResponseStatus, val bodySchema: BodySchema<A>) : ResponseSchema<A>
 
     fun getStatus(value: A): ResponseStatus =
         get(value).key
@@ -68,8 +68,9 @@ sealed interface ResponseSchema<A> {
             Single(status, BodySchema.schema()) { true }
 
         fun <A> sse(
+            status: ResponseStatus,
             schema: BodySchema.Companion.() -> BodySchema<A>
         ): ResponseSchema<A> =
-            EventStream(BodySchema.schema())
+            EventStream(status, BodySchema.schema())
     }
 }


### PR DESCRIPTION
## Problem

`KatalystClient.stream()` silently dropped non-2xx responses. An endpoint declaring typed errors (409, 400, etc.) would see its Flow complete with zero events on failure — no way to distinguish "server rejected us" from "stream ended normally." Downstream code was reduced to regex-matching exception messages.

## Fix

`stream()` now suspends until response headers arrive and returns `HttpResult<E, Flow<SSEEvent<O>>>`, mirroring `call()`:

- `Failure<E>` — server returned a declared error status with typed body
- `NetworkError` — transport, undeclared status, decode failure, pre-flight cancel
- `Success` — inner `Flow` carries events; mid-stream transport errors throw (use `.catch { }`)

Pre-flight failures and streaming are now structurally distinct — impossible to receive a typed `Failure` mid-stream, and mid-stream disconnects don't masquerade as pre-flight errors.

## Other changes

- `ResponseSchema.EventStream` now carries its declared status explicitly. `sse(Ok) { ... }` replaces `sse { ... }`, matching the existing `status(Conflict) { ... }` convention.
- Unified status matching: one `matchStatusSchema` helper drives both `call()` and `stream()`, with a dedicated `EventStream` variant instead of a hardcoded `200..299` check.

## Test plan

- [x] JVM: success, declared failure, undeclared failure, decode failure, connection failure, cancellation
- [x] JS: same six cases mirrored
- [x] Full multiplatform build green