### PR TITLE
feat(schema): add Record0 for empty records and union empty cases

### DIFF
--- a/schema-json-kotlinx/src/commonTest/kotlin/io/github/bbasinsk/schema/json/kotlinx/RecordSerdeTest.kt
+++ b/schema-json-kotlinx/src/commonTest/kotlin/io/github/bbasinsk/schema/json/kotlinx/RecordSerdeTest.kt
@@ -87,4 +87,33 @@ class RecordSerdeTest {
             schema.decodeFromJsonString("{}", Json.Default)
         )
     }
+
+    data object EmptyRecord
+
+    @Test
+    fun `empty record serializes to empty json object`() {
+        val schema = Schema.record { EmptyRecord }
+        assertEquals(
+            Json.parseToJsonElement("{}"),
+            schema.encodeToJsonElement(EmptyRecord)
+        )
+    }
+
+    @Test
+    fun `empty record deserializes from empty json object`() {
+        val schema = Schema.record { EmptyRecord }
+        assertEquals(
+            Validation.valid(EmptyRecord),
+            schema.decodeFromJsonString("{}", Json.Default)
+        )
+    }
+
+    @Test
+    fun `empty record deserializes ignoring extra fields`() {
+        val schema = Schema.record { EmptyRecord }
+        assertEquals(
+            Validation.valid(EmptyRecord),
+            schema.decodeFromJsonString("""{"extra": 1}""", Json.Default)
+        )
+    }
 }

--- a/schema-json-kotlinx/src/commonTest/kotlin/io/github/bbasinsk/schema/json/kotlinx/UnionSerdeTest.kt
+++ b/schema-json-kotlinx/src/commonTest/kotlin/io/github/bbasinsk/schema/json/kotlinx/UnionSerdeTest.kt
@@ -162,6 +162,64 @@ class UnionSerdeTest {
         )
     }
 
+    sealed interface Decision {
+        data object Save : Decision
+        data class Revise(val feedback: String) : Decision
+        data object Discard : Decision
+    }
+
+    private fun Schema.Companion.decision(): Schema<Decision> =
+        union(
+            case(record { Decision.Save }),
+            case(
+                record(
+                    field(string(), "feedback") { feedback },
+                    Decision::Revise
+                )
+            ),
+            case(record { Decision.Discard }),
+            key = "kind"
+        )
+
+    @Test
+    fun `union serializes empty case to discriminator-only object`() {
+        assertEquals(
+            Json.parseToJsonElement("""{"kind": "Save"}"""),
+            Schema.decision().encodeToJsonElement(Decision.Save)
+        )
+    }
+
+    @Test
+    fun `union serializes case with fields alongside discriminator`() {
+        assertEquals(
+            Json.parseToJsonElement("""{"kind": "Revise", "feedback": "make it vegetarian"}"""),
+            Schema.decision().encodeToJsonElement(Decision.Revise("make it vegetarian"))
+        )
+    }
+
+    @Test
+    fun `union deserializes empty case from discriminator-only object`() {
+        assertEquals(
+            Validation.valid(Decision.Save),
+            Schema.decision().decodeFromJsonString("""{"kind": "Save"}""", Json.Default)
+        )
+        assertEquals(
+            Validation.valid(Decision.Discard),
+            Schema.decision().decodeFromJsonString("""{"kind": "Discard"}""", Json.Default)
+        )
+    }
+
+    @Test
+    fun `union deserializes case with fields`() {
+        assertEquals(
+            Validation.valid(Decision.Revise("make it vegetarian")),
+            Schema.decision().decodeFromJsonString(
+                """{"kind": "Revise", "feedback": "make it vegetarian"}""",
+                Json.Default
+            )
+        )
+    }
+
     @Test
     fun `union serializes with custom discriminator`() {
         val schema = Schema.union(

--- a/schema/src/commonMain/kotlin/io/github/bbasinsk/schema/Schema.kt
+++ b/schema/src/commonMain/kotlin/io/github/bbasinsk/schema/Schema.kt
@@ -156,6 +156,10 @@ sealed interface Schema<A> {
                 deconstruct = deconstruct
             )
 
+        inline fun <reified A> record(
+            noinline construct: () -> (A)
+        ): Schema.Record<A> = Record0(metadataFromType(), construct)
+
         inline fun <reified A, B1> record(
             field1: Field<A, B1>,
             noinline construct: (B1) -> (A)

--- a/schema/src/commonMain/kotlin/io/github/bbasinsk/schema/SchemaRecord.kt
+++ b/schema/src/commonMain/kotlin/io/github/bbasinsk/schema/SchemaRecord.kt
@@ -1,5 +1,15 @@
 package io.github.bbasinsk.schema
 
+data class Record0<A>(
+    override val metadata: ObjectMetadata<A>,
+    val construct: () -> A
+) : Schema.Record<A> {
+    override val unsafeFields: List<Field<A, *>> = emptyList()
+
+    override fun unsafeConstruct(values: List<Any?>): A =
+        construct()
+}
+
 data class Record1<A, B1>(
     override val metadata: ObjectMetadata<A>,
     val field1: Field<A, B1>,


### PR DESCRIPTION
## Summary

- Adds `Record0<A>` (zero-field record) to `SchemaRecord.kt` and a matching `record(construct: () -> A)` factory in `Schema.Companion`. The smallest record was previously `Record1`, so empty objects (`{}`) had no representation.
- Unblocks modeling singleton/empty cases in discriminated unions — e.g. for the JSON shape

  ```json
  {"decision": {"kind": "Save"}}
  {"decision": {"kind": "Revise", "feedback": "change it"}}
  {"decision": {"kind": "Discard"}}
  ```

  the `Save`/`Discard` cases can now use `record { Decision.Save }` and the union encoder injects the `kind` discriminator over the empty `{}` body.
- All existing `Schema.Record` consumers (json-kotlinx, schema-json, avro, hocon, json-schema, openapi, ktor server/client adapters) iterate `unsafeFields` / call `unsafeConstruct(values)` and flow through naturally with `emptyList()` — no changes needed there.

## Test plan

- [x] `:schema-json-kotlinx:jvmTest` — added round-trip tests for standalone empty record and for the `decision`/`kind` union with `Save`, `Revise`, `Discard` cases (both encode and decode).
- [x] `./gradlew jvmTest` — full JVM test suite passes across all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)