### PR TITLE
fix(http): handle invalid request parameters

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 
 ktor2-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor2" }
 ktor2-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor2" }
+ktor2-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor2" }
 
 ktor3-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor3" }
 ktor3-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor3" }

--- a/http-server-ktor-2/build.gradle.kts
+++ b/http-server-ktor-2/build.gradle.kts
@@ -27,6 +27,11 @@ kotlin {
                 implementation(libs.kotlin.test)
             }
         }
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.ktor2.server.test.host)
+            }
+        }
     }
 }
 

--- a/http-server-ktor-2/src/commonMain/kotlin/io/github/bbasinsk/http/ktor2/KtorAdapter.kt
+++ b/http-server-ktor-2/src/commonMain/kotlin/io/github/bbasinsk/http/ktor2/KtorAdapter.kt
@@ -94,7 +94,9 @@ private fun <Path, Input, Error, Output> httpPipelineInterceptor(
         val rawPath = context.request.path().split("/").filter { it.isNotBlank() }
         val headers = context.request.headers.entries().associate { it.key to it.value }
         val query = context.request.queryParameters.entries().associate { it.key to it.value }
-        val path: Path = endpoint.api.params.parseCatching(rawPath.toMutableList(), headers, query).getOrThrow()
+        val path: Path = endpoint.api.params.parseCatching(rawPath.toMutableList(), headers, query).getOrElse {
+            return@interceptor call.respond(HttpStatusCode.BadRequest)
+        }
 
         val input = call.receiveRequest(endpoint.api.input)
             .getOrElse { errors ->

--- a/http-server-ktor-2/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor2/KtorAdapterTest.kt
+++ b/http-server-ktor-2/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor2/KtorAdapterTest.kt
@@ -1,0 +1,36 @@
+package io.github.bbasinsk.http.ktor2
+
+import io.github.bbasinsk.http.Http
+import io.github.bbasinsk.http.Response
+import io.github.bbasinsk.http.header
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KtorAdapterTest {
+    @Test
+    fun headerParameterNamesAreCaseInsensitiveAndMissingValuesReturnBadRequest() = testApplication {
+        val api = Http.get { Root / "recipe" }
+            .header { schema("Content-Location") { string() } }
+            .output { status(Ok) { plain { string() } } }
+
+        application {
+            endpoints {
+                handle(api) { request -> Response.success(request.params) }
+            }
+        }
+
+        val parsed = client.get("/recipe") {
+            header("content-location", "https://example.com/recipe")
+        }
+        val missing = client.get("/recipe")
+
+        assertEquals(HttpStatusCode.OK, parsed.status)
+        assertEquals("https://example.com/recipe", parsed.bodyAsText())
+        assertEquals(HttpStatusCode.BadRequest, missing.status)
+    }
+}

--- a/http-server-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
+++ b/http-server-ktor-3/src/commonMain/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapter.kt
@@ -86,7 +86,9 @@ private fun <Path, Input, Error, Output, Auth> httpRoutingHandler(
         .map { it.decodeURLPart() }
     val headers = call.request.headers.entries().associate { it.key to it.value }
     val query = call.request.queryParameters.entries().associate { it.key to it.value }
-    val path: Path = endpoint.api.params.parseCatching(rawPath.toMutableList(), headers, query).getOrThrow()
+    val path: Path = endpoint.api.params.parseCatching(rawPath.toMutableList(), headers, query).getOrElse {
+        return@interceptor call.respond(HttpStatusCode.BadRequest)
+    }
 
     val auth: Auth = when (val result = handleAuth(endpoint.api.auth, endpoint.authHandler, call.request.headers, call.request.cookies, query)) {
         is AuthResult.Success -> result.principal

--- a/http-server-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapterTest.kt
+++ b/http-server-ktor-3/src/jvmTest/kotlin/io/github/bbasinsk/http/ktor3/KtorAdapterTest.kt
@@ -3,6 +3,7 @@ package io.github.bbasinsk.http.ktor3
 import io.github.bbasinsk.http.ContentType as KatalystContentType
 import io.github.bbasinsk.http.Http
 import io.github.bbasinsk.http.Response
+import io.github.bbasinsk.http.header
 import io.github.bbasinsk.http.query
 import io.github.bbasinsk.schema.Schema
 import io.github.bbasinsk.schema.java.instant
@@ -21,6 +22,28 @@ class KtorAdapterTest {
     val json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = false
+    }
+
+    @Test
+    fun headerParameterNamesAreCaseInsensitiveAndMissingValuesReturnBadRequest() = testApplication {
+        val api = Http.get { Root / "recipe" }
+            .header { schema("Content-Location") { string() } }
+            .output { status(Ok) { plain { string() } } }
+
+        application {
+            endpoints {
+                handle(api) { request -> Response.success(request.params) }
+            }
+        }
+
+        val parsed = client.get("/recipe") {
+            header("content-location", "https://example.com/recipe")
+        }
+        val missing = client.get("/recipe")
+
+        assertEquals(HttpStatusCode.OK, parsed.status)
+        assertEquals("https://example.com/recipe", parsed.bodyAsText())
+        assertEquals(HttpStatusCode.BadRequest, missing.status)
     }
 
     @Test

--- a/http/src/commonMain/kotlin/io/github/bbasinsk/http/ParamsSchema.kt
+++ b/http/src/commonMain/kotlin/io/github/bbasinsk/http/ParamsSchema.kt
@@ -123,7 +123,7 @@ fun <A> ParamsSchema<A>.parse(
     rawQueryParams: Map<String, List<String>>,
 ): A {
     return when (this) {
-        is ParamsSchema.HeaderSchema -> this.param.parse { name -> rawHeaders[name] }
+        is ParamsSchema.HeaderSchema -> this.param.parse { name -> rawHeaders.headerValues(name) }
         is ParamsSchema.QuerySchema -> this.param.parse { name ->
             rawQueryParams[name].takeIf { it != listOf("") } // handle `?name=` as null
         }
@@ -176,6 +176,9 @@ fun <A> ParamsSchema<A>.parse(
         }
     }
 }
+
+private fun Map<String, List<String>>.headerValues(name: String): List<String>? =
+    entries.firstOrNull { (headerName) -> headerName.equals(name, ignoreCase = true) }?.value
 
 data class RenderedParams(
     val pathSegments: List<String>,

--- a/http/src/commonTest/kotlin/io/github/bbasinsk/http/ParamsSchemaTest.kt
+++ b/http/src/commonTest/kotlin/io/github/bbasinsk/http/ParamsSchemaTest.kt
@@ -12,6 +12,22 @@ import kotlin.uuid.Uuid
 class ParamsSchemaTest {
 
     @Test
+    fun `it parses header names case insensitively`() {
+        val http = Http
+            .get { Root / "recipe" }
+            .header { schema("Content-Location") { string() } }
+
+        val found = http.params.parseCatching(
+            path = listOf("recipe"),
+            headers = mapOf("content-location" to listOf("https://example.com/recipe")),
+            queryParams = emptyMap()
+        ).getOrThrow()
+
+        val (contentLocation) = tupleValues(found)
+        assertEquals("https://example.com/recipe", contentLocation)
+    }
+
+    @Test
     fun `it parses list query param`() {
         val http = Http
             .get { Root / "eval" / "invocations" }


### PR DESCRIPTION
## What

Make header parameter lookup case-insensitive. Return HTTP 400 when path, query, or header parsing fails in Ktor 2 and 3.

## Why

`http/ParamsSchema.kt` treated header map keys as case-sensitive. HTTP transports can normalize `Content-Location` to `content-location`, so valid requests failed decoding.

Both Ktor adapters rethrew parameter failures. Ktor then returned HTTP 500 for malformed request parameters.

## How to verify

1. Run `./gradlew :http:jvmTest :http-server-ktor-2:jvmTest :http-server-ktor-3:jvmTest`.
2. Run `./gradlew check`.
3. Send a lowercase required header and confirm the endpoint returns HTTP 200.
4. Omit a required header and confirm the endpoint returns HTTP 400.

## Out of scope

- Request body decoding still uses HTTP 422.
- Error response bodies remain unchanged.

## Risk and rollback

Low risk. The behavior change expands valid header matching and changes invalid parameter responses from 500 to 400. Revert `b49eb43` to roll back.